### PR TITLE
Patch addRequest to support newer APIs

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,12 @@ ForeverAgent.defaultMinSockets = 5
 ForeverAgent.prototype.createConnection = net.createConnection
 ForeverAgent.prototype.addRequestNoreuse = Agent.prototype.addRequest
 ForeverAgent.prototype.addRequest = function(req, host, port) {
+  if (typeof host !== 'string') {
+    var options = host
+    port = options.port
+    host = options.host
+  }
+
   var name = host + ':' + port
   if (this.freeSockets[name] && this.freeSockets[name].length > 0 && !req.useChunkedEncodingByDefault) {
     var idleSocket = this.freeSockets[name].pop()


### PR DESCRIPTION
ForeverAgent.addRequest is called with different arguments
when running in Node 0.12 and iojs latest.
This will homogenous the arguments in the case the user runs
ForeverAgent in Node 0.12 and iojs, while keeping support for Node 0.10